### PR TITLE
fix: No public IP for ec2 instances

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -585,7 +585,7 @@ Resources:
       LaunchTemplateData:
         NetworkInterfaces:
           - DeviceIndex: 0
-            AssociatePublicIpAddress: true
+            AssociatePublicIpAddress: false
             Groups:
               - !Ref InstanceSecurityGroup
             DeleteOnTermination: true


### PR DESCRIPTION
The instances created for terraform are in private network and doesn't require a public IP. Outbound connections are via NAT gateway and the command execution is via SSM which doesn't require any inbound connection.

Note: Technically this might not cause any issue. But it is unnecessary, confusing and not a good practice.